### PR TITLE
suppression warnings

### DIFF
--- a/classes/factories/trainings_factory.php
+++ b/classes/factories/trainings_factory.php
@@ -214,7 +214,7 @@ class trainings_factory extends singleton {
         $lastid = db_accessor::get_instance()->insert_training($category->get_id());
 
         // If OK, call $this->create with the category object.
-        $this->create($category, $lastid);
+        $this->create($category, $lastid, "");
 
         return true;
     }

--- a/classes/forms/period_form.php
+++ b/classes/forms/period_form.php
@@ -39,7 +39,6 @@ class period_form extends \moodleform {
      * all the elements (inputs, titles, buttons, ...) in the form.
      */
     public function definition() {
-        $inputnameprefix = $this->_customdata['input_name_prefix'];
         $mform = $this->_form;
         $group = array();
         $group[] =& $mform->createElement('date_selector', 'input_begin_date', '');

--- a/classes/forms/training_milestones_update_form.php
+++ b/classes/forms/training_milestones_update_form.php
@@ -117,11 +117,15 @@ class training_milestones_update_form extends \moodleform {
 
         $filtergroup[] =& $mform->createElement('static', null, null, get_string('filtermodulevisible', 'tool_attestoodle'));
         $filtergroup[] =& $mform->createElement('select', 'visibmod', '', $selectyesno, null);
-        $mform->setDefault('visibmod', $this->_customdata['visibmod']);
+        if (isset($this->_customdata['visibmod'])) {
+            $mform->setDefault('visibmod', $this->_customdata['visibmod']);
+        }
 
         $filtergroup[] =& $mform->createElement('static', null, null, get_string('filtermodulerestrict', 'tool_attestoodle'));
         $filtergroup[] =& $mform->createElement('select', 'restrictmod', '', $selectyesno, null);
-        $mform->setDefault('restrictmod', $this->_customdata['restrictmod']);
+        if (isset($this->_customdata['restrictmod'])) {
+            $mform->setDefault('restrictmod', $this->_customdata['restrictmod']);
+        }
 
         $filtergroup[] =& $mform->createElement('submit', 'filter',
             get_string('filtermodulebtn', 'tool_attestoodle'), array('class' => 'send-button'));
@@ -146,11 +150,13 @@ class training_milestones_update_form extends \moodleform {
 
         foreach ($activities as $activity) {
             $pass = $this->filtertype($activity, $filtertype, $lib);
-            if ($pass && $this->_customdata['visibmod'] == 1) {
-                $pass = $activity->visible;
-            }
-            if ($pass && $this->_customdata['visibmod'] == 2) {
-                $pass = !$activity->visible;
+            if (isset($this->_customdata['visibmod'])) {
+                if ($pass && $this->_customdata['visibmod'] == 1) {
+                    $pass = $activity->visible;
+                }
+                if ($pass && $this->_customdata['visibmod'] == 2) {
+                    $pass = !$activity->visible;
+                }
             }
             $pass = $this->filterrestrict($activity, $pass);
             // The filter on the name has priority.
@@ -206,6 +212,9 @@ class training_milestones_update_form extends \moodleform {
      */
     private function filterrestrict($activity, $pass) {
         $ret = $pass;
+        if (!isset($this->_customdata['restrictmod'])) {
+            return $ret;
+        }
         if ($ret && $this->_customdata['restrictmod'] == 0) {
             return $ret;
         }

--- a/classes/gabarit/simul_pdf.php
+++ b/classes/gabarit/simul_pdf.php
@@ -87,8 +87,8 @@ class simul_pdf extends attestation_pdf {
     private function printactivities($model, $tabactivities) {
         $width = $this->computewidth($model);
         $x = $this->comput_align($model, $width);
-        if ($x + $minwidth > $this->pageparam->pagewidth) {
-            $x = $this->pageparam->pagewidth - $minwidth;
+        if ($x + 80 > $this->pageparam->pagewidth) {
+            $x = $this->pageparam->pagewidth - 80;
         }
         $y = intval($model->location->y) + $this->offset;
         $heightline = intval($model->font->size);

--- a/classes/gabarit/sitecertificate.php
+++ b/classes/gabarit/sitecertificate.php
@@ -36,6 +36,8 @@ $context = context_system::instance();
 $idtemplate = optional_param('templateid', null, PARAM_INT);
 $lnkidtemplate = $idtemplate;
 
+$namelock = 0;
+
 if (!isset($idtemplate)) {
     $template = $DB->get_record('tool_attestoodle_template', array('name' => 'Site'));
     $idtemplate = $template->id;
@@ -48,7 +50,6 @@ if (!isset($idtemplate)) {
         $template = $DB->get_record('tool_attestoodle_template', array('name' => 'Site'));
         $idtemplate = $template->id;
         $template->name = '';
-        $namelock = 0;
         $previewok = false;
         $create = true;
     } else {
@@ -92,7 +93,7 @@ if ($fromform = $mform->get_data()) {
         return;
     }
 
-    if ($datas->name != null) {
+    if (isset($datas->name)) {
         // Create.
         if (!$DB->record_exists('tool_attestoodle_template', array('name' => $datas->name))) {
             $model = new stdClass();
@@ -190,7 +191,11 @@ if ($fromform = $mform->get_data()) {
     }
 
     // Type pagebreak.
-    $nvxtuples[] = pagebreak_to_structure($idtemplate, $datas->viewpagenumber, $datas->repeatbackground,
+    $repeatimg = false;
+    if (isset($datas->repeatbackground)) {
+        $repeatimg = true;
+    }
+    $nvxtuples[] = pagebreak_to_structure($idtemplate, $datas->viewpagenumber, $repeatimg,
                 $datas->repeatpreactivities, $datas->repeatpostactivities, $backgroundexist);
     // Type numpage.
     if ($datas->viewpagenumber > 0) {
@@ -353,7 +358,7 @@ function pagebreak_to_structure($dtotemplateid, $dtoviewpagenum, $dtorepeatbackg
     }
     $valeurs->numpage = $numpage;
     $repeatbackground = false;
-    if (isset($dtorepeatbackgr) && $backgroundexist) {
+    if ($dtorepeatbackgr && $backgroundexist) {
         $repeatbackground = true;
     }
     $valeurs->repeatbackground = $repeatbackground;

--- a/classes/gabarit/view_export.php
+++ b/classes/gabarit/view_export.php
@@ -75,7 +75,6 @@ if (isset($idtraining)) {
 
 $exp->set_infos($certificateinfos);
 $exp->print_activity();
-echo $OUTPUT->footer();
 
 /**
  * creating a test set to trigger overflows.

--- a/classes/output/renderable/training_milestones.php
+++ b/classes/output/renderable/training_milestones.php
@@ -130,7 +130,7 @@ class training_milestones implements \renderable {
             // If data are valid, process persistance.
             // Try to retrieve the submitted data.
             $datafromform = $this->form->get_submitted_data();
-            if ($datafromform->filter) {
+            if (isset($datafromform->filter)) {
                 $url = new \moodle_url('/admin/tool/attestoodle/index.php',
                 [
                 'page' => 'managemilestones',

--- a/index.php
+++ b/index.php
@@ -106,8 +106,8 @@ switch($page) {
         $begindate = optional_param('begindate', null, PARAM_ALPHANUMEXT);
         $enddate = optional_param('enddate', null, PARAM_ALPHANUMEXT);
 
-        $start = optional_param('input_begin_date', null, PARAM_INT);
-        $end = optional_param('input_end_date', null, PARAM_INT);
+        $start = optional_param_array('input_begin_date', null, PARAM_INT);
+        $end = optional_param_array('input_end_date', null, PARAM_INT);
 
         if (isset($start)) {
             $begindate = "" . $start['year'] . "-" . $start['month'] . "-" . $start['day'];


### PR DESCRIPTION
Liste des warnings soulevés par guillaume mail du 11/12
- core_render::image_url() -> pas de correction provient de la version de la plateforme
- issue #31 -issue #33 -TCPDF ERROR : un warning pertube la création du pdf, warning undefined minwidth -> CORRIGE
-missing argument 3 dans trainings_factory::create(), warning soulever malgrés la valeurs par défaut sur le 3ieme paramètre ->CORRIGE
-issue #32 -Undefined visibmod,restrictmod dans le filtre des jalons -> CORRIGE
-issue #37 -Undefined $repeatbackground, $namelock dans enregistrement de modèle d'attestation => CORRIGE
-issue #34 -issue #36 -Undefined input_name_prefix dans filtre de la période => CORRIGE
-problem certifcate SSL -> pas de correction provient de la plateforme de test
-issue #38 -invalid array parameter detected pour input_begin_date et input_end_begin_date => CORRIGE

cela corrige plusieurs issue créées après le mail de guillaume, mais plusieurs issue concerne un même problème !